### PR TITLE
cleaned up readme and added separate data page for readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This project explores how wildfires have affected Australia over time through data visualizations, including interactive time series charts, plots and a map. Visit our [website](https://australia-fire-api-dashboard.herokuapp.com/) to learn more.
 
-For this project, we collected open data from a number of sources, including data captured by NASA satellites and various wildfire and climate data. 
+For this project, we collected open data from a number of sources, including data captured by NASA satellites and various wildfire and climate data. More information about our sources and the data itself can be found in the [Data page](./docs/data.md) in the `docs` folder.
 
 Following, we'll share a background of the project and explain how to recreate the webapp locally, using the code and data shared in this repo.
 

--- a/README.md
+++ b/README.md
@@ -2,43 +2,41 @@
 
 ## Background
 
-This project explores how wildfires have affected Australia over time through data visualizations, including interactive time series charts, plots and a map. Visit our [website](https://australia-fire-api-dashboard.herokuapp.com/) to learn more.
+This project explores how wildfires have affected Australia over time through data visualizations, including interactive time series charts, plots and a map. Visit the [website](https://australia-fire-api-dashboard.herokuapp.com/) to learn more.
 
-For this project, we collected open data from a number of sources, including data captured by NASA satellites and various wildfire and climate data. More information about our sources and the data itself can be found in the [Data page](./docs/data.md) in the `docs` folder.
+This project incorporates open data from a number of sources, including data captured by NASA satellites and various wildfire and climate data. More information about the sources and the data itself can be found in the [Data page](./docs/data.md) in the `docs` folder.
 
-Following, we'll share a background of the project and explain how to recreate the webapp locally, using the code and data shared in this repo.
+This README includes background information about the project and steps on how to set up the application locally.
 
 ### Technologies Used
 
-#### Infrastructure
+#### Backend
 
-- [Flask](https://flask.palletsprojects.com/en/1.1.x/), a Python micro web framework used to run our API.
+- [Flask](https://flask.palletsprojects.com/en/1.1.x/), a Python micro web framework used to run the application.
 - [MongoDB](https://www.mongodb.com/), a NoSQL for storing the data locally.
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), for storing the data in the cloud.
-- [Heroku](https://www.heroku.com/), for running our dashboard in the cloud.
+- [Heroku](https://www.heroku.com/), for running the dashboard in the cloud.
 - [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/running.html), for running Python code within a larger document.
 - [Python](https://www.python.org/), including packages like [pandas](https://pandas.pydata.org/) and [Beautiful Soup](https://pypi.org/project/beautifulsoup4/).
 
-#### Data visualization
+#### Frontend
 
-- [D3.js](https://d3js.org/), a Javascript data visualization library.
-- [d3-timeseries](https://github.com/mcaule/d3-timeseries), a plugin for building time series charts.
-- [Leaflet](https://leafletjs.com/), a Javascript library for building interactive maps.
+- [D3.js](https://d3js.org/), a JavaScript data visualization library.
+- [d3-timeseries](https://github.com/mcaule/d3-timeseries), a library for building time series charts.
+- [Leaflet](https://leafletjs.com/), a JavaScript library for building interactive maps.
 
 
 ## Installation
 
-### Step 0. Clone the repo
+### Step 1. Clone the repo
 
-First, you'll need to clone the repository by running:
+Download or clone this repository.
 
-```git clone git@github.com:philipstubbs13/australia-fire-api-and-dashboard.git```
-
-### Step 1. Load the data
+### Step 2. Load the data
 
 The data for this project is stored in a MongoDB database.
 
-Background information on the [Data](https://australia-fire-api-dashboard.herokuapp.com/data) sources can be found on [our website](https://australia-fire-api-dashboard.herokuapp.com/data), and a detailed list of fields and data types for each database can be found in the [Data page](./docs/data.md) in `docs`.
+Background information on the [Data](https://australia-fire-api-dashboard.herokuapp.com/data) sources can be found on [the website](https://australia-fire-api-dashboard.herokuapp.com/data), and a detailed list of fields and data types for each collection can be found in the [Data page](./docs/data.md) in `docs`.
 
 To load the data into a local database, perform these steps:
 
@@ -50,11 +48,11 @@ To load the data into a local database, perform these steps:
 
 3. Verify that the data is inserted into the database properly by opening MongoDB from Git Bash/Terminal or using a program like MongoDB Compass and looking for the **australia_fire_db** database. 
 
-### Step 2. Start a Flask Server
+### Step 3. Start a Flask Server
 
-The API and the site for this project are built using the Flask framework. To start a Flask server locally:
+The API and the application for this project are built using the Flask framework. To start a Flask server locally:
 
-1. Activate a Python virtual environment that has the appropriate packages installed (for fellow Bootcamp users, this will be the `PythonData` environment):
+1. Activate a Python virtual environment that has the appropriate packages installed, as shown in the following example:
 
 ```bash
 conda activate PythonData
@@ -68,11 +66,11 @@ conda activate PythonData
 python app.py
 ```
 
-This starts the Flask server on port 5000. You can then copy and paste the Flask URL into your browser to see the locally-hosted website in action.
+This starts the Flask server on port 5000. You can then copy and paste the Flask URL into your browser to see the locally-hosted application in action.
 
-### Step 3. Use the API to build visualizations
+## Using the API to build visualizations
 
-- All of the interactive visualizations in our project use our API and its various endpoints.  Information about the different endpoints can be found [on our website](https://australia-fire-api-dashboard.herokuapp.com/api/v1.0/docs) and [in the `docs`](./docs/data.md).
+- The visualizations for this project are powered using the API endpoints.  Information about the different endpoints can be found [on the website](https://australia-fire-api-dashboard.herokuapp.com/api/v1.0/docs) and [in the `docs`](./docs/data.md).
 
 - Here's an example of how to retrieve data from the `fires_modis` API endpoint using `d3`:
 
@@ -83,23 +81,28 @@ d3.json(url).then(data => {
 });
 ```
 
-- You can build on our work by creating your own visualizations using the API. Examples for how to integrate the data retrieved from the API into visualizations including charts and maps can be found in [`static/js`](./static/js).
+- You can build on this work by creating your own visualizations using the API. Examples for how to integrate the data retrieved from the API into visualizations including charts and maps can be found in [`static/js`](./static/js).
 
-#### Rendering the bushfire map 
+### Rendering the bushfire map 
 
-To view the live bushfire map on your own machine, you'll need to create and save a `config.py` file in the root directory within the **application** folder of this repository that includes a Mapbox API key in the following format:
+To view the live bushfire map locally:
+
+1. Create and save a `config.py` file in the root directory within the **application** folder of this repository.
+2. Add the following line to the `config.py` file:
 
 ```py
-API_KEY = "your key here"
+API_KEY = "your_key_here"
 ```
 
-More information on Mapbox API keys can be found on [their website](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/).
+Replace `your_key_here` with your Mapbox API key. More information on Mapbox API keys can be found on [the Mapbox website](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/).
 
-### Step 5. Deploy the site to Heroku
+## Deploying the application to Heroku
 
-The site is deployed to Heroku, where the API and app are hosted. It is currently hosted at <https://australia-fire-api-dashboard.herokuapp.com/>.
+The application is deployed to Heroku. It is currently hosted at <https://australia-fire-api-dashboard.herokuapp.com/>.
 
-To get started, we recommend checking out the [official instructions](https://devcenter.heroku.com/articles/git) for setting up an app on Heroku.
+To get started, check out the [official instructions](https://devcenter.heroku.com/articles/git) for setting up an app on Heroku.
+
+Note: If you add a Python package to the app, make sure you add that package to the **requirements.txt** file in the root directory of your version of the project.
 
 To deploy a branch from Heroku:
 
@@ -109,11 +112,6 @@ To deploy a branch from Heroku:
 4. Choose a branch to deploy from the dropdown (it will most likely be the master branch).
 5. Click **Deploy Branch**.
 
-Note: If you add a Python package to the app, make sure you add that package to the **requirements.txt** file in the root directory of your version of the project.
-
 ## License
 
-You are welcome to fork this repo and build upon our work under the terms of an MIT license.
-
-
-
+You are welcome to fork this repo and build upon this work under the terms of an MIT license.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This README includes background information about the project and steps on how t
 #### Backend
 
 - [Flask](https://flask.palletsprojects.com/en/1.1.x/), a Python micro web framework used to run the application.
-- [MongoDB](https://www.mongodb.com/), a NoSQL for storing the data locally.
+- [MongoDB](https://www.mongodb.com/), a NoSQL database for storing the data locally.
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), for storing the data in the cloud.
 - [Heroku](https://www.heroku.com/), for running the dashboard in the cloud.
 - [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/running.html), for running Python code within a larger document.

--- a/README.md
+++ b/README.md
@@ -1,141 +1,60 @@
-# Australia API and Dashboard
+# Australian Bushfire API and Dashboard
 
 ## Background
 
-This project explores how wildfires have affected the country of Australia over time. Specifically, for this project, we gathered data captured by NASA satellites and various historical wildfire and climate data to help visualize what Australia not only has been through historically but also what Australia has gone through with the most recent (2019-2020) wildfire season. Go to our [website](https://australia-fire-api-dashboard.herokuapp.com/) to learn more about this project.
+This project explores how wildfires have affected Australia over time through data visualizations, including interactive time series charts, plots and a map. Visit our [website](https://australia-fire-api-dashboard.herokuapp.com/) to learn more.
 
-## Loading data into a database
+For this project, we collected open data from a number of sources, including data captured by NASA satellites and various wildfire and climate data. 
+
+Following, we'll share a background of the project and explain how to recreate the webapp locally, using the code and data shared in this repo.
+
+### Technologies Used
+
+#### Infrastructure
+
+- [Flask](https://flask.palletsprojects.com/en/1.1.x/), a Python micro web framework used to run our API.
+- [MongoDB](https://www.mongodb.com/), a NoSQL for storing the data locally.
+- [MongoDB Atlas](https://www.mongodb.com/cloud/atlas), for storing the data in the cloud.
+- [Heroku](https://www.heroku.com/), for running our dashboard in the cloud.
+- [Jupyter Notebook](https://jupyter.readthedocs.io/en/latest/running.html), for running Python code within a larger document.
+- [Python](https://www.python.org/), including packages like [pandas](https://pandas.pydata.org/) and [Beautiful Soup](https://pypi.org/project/beautifulsoup4/).
+
+#### Data visualization
+
+- [D3.js](https://d3js.org/), a Javascript data visualization library.
+- [d3-timeseries](https://github.com/mcaule/d3-timeseries), a plugin for building time series charts.
+- [Leaflet](https://leafletjs.com/), a Javascript library for building interactive maps.
+
+
+## Installation
+
+### Step 0. Clone the repo
+
+First, you'll need to clone the repository by running:
+
+```git clone git@github.com:philipstubbs13/australia-fire-api-and-dashboard.git```
+
+### Step 1. Load the data
 
 The data for this project is stored in a MongoDB database.
 
-For more information on where this data came from, see the [Data](https://australia-fire-api-dashboard.herokuapp.com/data) page of the site.
+Background information on the [Data](https://australia-fire-api-dashboard.herokuapp.com/data) sources can be found on [our website](https://australia-fire-api-dashboard.herokuapp.com/data), and a detailed list of fields and data types for each database can be found in the [Data page](./docs/data.md) in `docs`.
 
 To load the data into a local database, perform these steps:
 
-1. [Install MongoDB](https://docs.mongodb.com/manual/administration/install-community/)
-2. Start MongoDB locally by running `mongod` from the terminal.
-3. Open the [etl_fires_from_space.ipynb](./etl_fires_from_space.ipynb) jupyter notebook file and run the cells to extract, transform, and load the data.
-4. Open the [WebScrapping.ipynb](./WebScraping.ipynb) jupyter notebook file and run the cells to scrape and load the data.
-5. Open the [temp_rainfall.ipynb](./temp_rainfall.ipynb) jupyter notebook file and run the cells to extract, transform, and load the data.
-6. Verify the data is inserted by opening MongoDB Compass and looking for the **australia_fire_db** database.
+1. Start MongoDB locally by running `mongod` from Git Bash/Terminal.
+2. Launch a Jupyter Notebook from Git Bash/Terminal (by running `jupyter notebook`). Note that you will likely need to install some packages like `pandas`, `Beautiful Soup`, `pymongo`, and `numpy` to get the notebooks up and running. Open and run:
+    * [etl_fires_from_space.ipynb](./etl_fires_from_space.ipynb)
+    * [WebScraping.ipynb](./WebScraping.ipynb) 
+    * [temp_rainfall.ipynb](./temp_rainfall.ipynb) 
 
-## Data Structure
+3. Verify that the data is inserted into the database properly by opening MongoDB from Git Bash/Terminal or using a program like MongoDB Compass and looking for the **australia_fire_db** database. 
 
-The **australia_fire_db** currently has the following collections:
+### Step 2. Start a Flask Server
 
-- **fires_modis** - includes australia fires detected by MODIS (Moderate Resolution Imaging Spectroradiometer) satellite sensors.
+The API and the site for this project are built using the Flask framework. To start a Flask server locally:
 
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `acq_date`   | String |
-|  `acq_time` | Int |
-| `bright_t31` | Double |
-| `brightness` | Double |
-| `daynight` | String |
-| `frp` | Double |
-| `instrument` | String |
-| `latitude` | Double |
-| `longitude` | Double |
-| `satellite` | String |
-
-- **fires_viirs** - includes australia fires detected by VIIRS (Visible Infrared Imaging Radiometer Suite) satellite sensors.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `acq_date`   | String |
-|  `acq_time` | Int |
-| `bright_ti4` | Double |
-| `bright_ti5` | Double |
-| `frp` | Double |
-| `instrument` | String |
-| `latitude` | Double |
-| `longitude` | Double |
-| `satellite` | String |
-
-- **historicalFires** - includes information about past Australia fire seasons.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `Date`   | String |
-|  `Name` | String |
-| `State(s)/territories` | String |
-| `AreaBurned(ha)` | Int |
-| `AreaBurned(acres)` | Int |
-| `Fatalities` | Int |
-| `PropertiesDamaged(HomesDestroyed)` | Int |
-| `Year` | Int |
-
-- **temp_rainfall** - includes Australian average annual max temperatures and rainfall from 1956-2019.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `Year`   | Int |
-|  `Avg Annual Temp` | Double|
-| `Avg Annual Rainfall` | Double |
-| `temp_differnce` | Double |
-| `rainfall_difference` | Double |
-
-- **bushfiresbyState** - includes information about the 2019-2020 bushfire season by state.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `State/Territory`   | String |
-|  `Fatalities` | Int |
-| `Homeslost` | Int |
-| `Areaestimated(ha)` | Int |
-| `Areaestimated(acres)` | Int |
-
-- **aus2019_2020** - includes additional information about the 2019-2020 bushfire season.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `Fire`   | String |
-|  `Name` | String |
-| `State` | String |
-| `Local Government Area(s)` | String |
-| `AreaImpacted(ha)` | Int |
-
-- **fires_time_series** - includes the number of fires captured by NASA satellites each day
-during the 2019-20 Australia fire season. This collection is used to create the D3 time series chart for this project.
-
-| Field       | Type
-| :------------- | :----------: |
-|  `_id` | ObjectId |
-| `acq_date`   | String |
-|  `number_fires` | Int |
-
-## Data Flow
-
-![Data Flow](./images/data_flow.png)
-
-## Technologies Used
-
-- D3
-- [d3-timeseries](https://github.com/mcaule/d3-timeseries) for building the time series chart (new JavaScript library used for this project)
-- MongoDB (for storing the data locally) and MongoDB Atlas (for storing the data in the cloud).
-- Leaflet
-- Heroku
-- Python
-- Pandas
-- Beautiful Soup
-
-## Original Datasets
-
-The original datasets/csv files are stored in this repository as zip files in the [Resources](./Resources) folder.
-
-This repo uses Git LFS to store the large dataset files on GitHub. To install Git LFS, go [here](https://git-lfs.github.com/).
-
-## Starting the Flask Server
-
-The API and the site for this project are built using the Flask framework. To start the Flask server locally:
-
-1. Activate the python virtual environment:
+1. Activate a Python virtual environment that has the appropriate packages installed (for fellow Bootcamp users, this will be the `PythonData` environment):
 
 ```bash
 conda activate PythonData
@@ -149,13 +68,13 @@ conda activate PythonData
 python app.py
 ```
 
-This starts the Flask server on port 5000.
+This starts the Flask server on port 5000. You can then copy and paste the Flask URL into your browser to see the locally-hosted website in action.
 
-## Using the API
+### Step 3. Use the API to build visualizations
 
-- Information about the different endpoints available can be found [here](https://australia-fire-api-dashboard.herokuapp.com/api/v1.0/docs).
+- All of the interactive visualizations in our project use our API and its various endpoints.  Information about the different endpoints can be found [on our website](https://australia-fire-api-dashboard.herokuapp.com/api/v1.0/docs) and [in the `docs`](./docs/data.md).
 
-- An example of how to get data from API using `d3.json`:
+- Here's an example of how to retrieve data from the `fires_modis` API endpoint using `d3`:
 
 ```bash
 const url = "https://australia-fire-api-dashboard.herokuapp.com/api/v1.0/fires_modis"
@@ -164,11 +83,11 @@ d3.json(url).then(data => {
 });
 ```
 
-Another example can be found [here](./application/static/js/buildDataTable.js).
+- You can build on our work by creating your own visualizations using the API. Examples for how to integrate the data retrieved from the API into visualizations including charts and maps can be found in [`static/js`](./static/js).
 
-## Rendering the bushfire map locally
+#### Rendering the bushfire map 
 
-To view the live bushfire map on your own machine, you'll need to create and save a `config.py` file in the root directory within the **application** folder of this repository with a Mapbox API key included in the following format:
+To view the live bushfire map on your own machine, you'll need to create and save a `config.py` file in the root directory within the **application** folder of this repository that includes a Mapbox API key in the following format:
 
 ```py
 API_KEY = "your key here"
@@ -176,11 +95,11 @@ API_KEY = "your key here"
 
 More information on Mapbox API keys can be found on [their website](https://docs.mapbox.com/help/how-mapbox-works/access-tokens/).
 
-## Deployment
+### Step 5. Deploy the site to Heroku
 
 The site is deployed to Heroku, where the API and app are hosted. It is currently hosted at <https://australia-fire-api-dashboard.herokuapp.com/>.
 
-Note: If you add a python package to the app, you will need to add that package to the **requirements.txt** file in the root directory of this project.
+To get started, we recommend checking out the [official instructions](https://devcenter.heroku.com/articles/git) for setting up an app on Heroku.
 
 To deploy a branch from Heroku:
 
@@ -189,3 +108,12 @@ To deploy a branch from Heroku:
 3. Scroll all the way to the bottom to the **Manual Deploy** section.
 4. Choose a branch to deploy from the dropdown (it will most likely be the master branch).
 5. Click **Deploy Branch**.
+
+Note: If you add a Python package to the app, make sure you add that package to the **requirements.txt** file in the root directory of your version of the project.
+
+## License
+
+You are welcome to fork this repo and build upon our work under the terms of an MIT license.
+
+
+

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,112 @@
+# About the data
+
+## Data Flow
+
+![Data Flow](../images/data_flow.png)
+
+## Sources
+
+- [Fires from Space: Australia](https://www.kaggle.com/carlosparadis/fires-from-space-australia-and-new-zeland) by Carlos Paradis.
+- [List of 2019-2020 bushfires by state](https://en.wikipedia.org/wiki/List_of_fires_and_impacts_of_the_2019-20_Australian_bushfire_season) from Wikipedia.
+- [List of Major Bushfires in Australia](https://en.wikipedia.org/wiki/List_of_major_bushfires_in_Australia) from Wikipedia.
+- [2019 - 2020 Australian bushfire season](https://en.wikipedia.org/wiki/2019%E2%80%9320_Australian_bushfire_season) from Wikipedia.
+- [GeoJSON-formatted Australian state and township border data](https://github.com/tonywr71/GeoJson-Data) by [tonywr71](https://github.com/tonywr71).
+- [Australian Climate Data](http://www.bom.gov.au/climate/data/) from the Australian Government Bureau of Meteorology. 
+
+## Original Datasets
+
+A few of the original datasets are stored in this repository as zip files in the [Resources](./Resources) folder, for posterity. Other data was scraped from Wikipedia.
+
+This repo uses Git LFS to store the large dataset files on GitHub. To install Git LFS, visit the [Git-LFS site](https://git-lfs.github.com/).
+
+## Database Structure
+
+The **australia_fire_db** currently has the following collections:
+
+- **fires_modis** - Includes Australian fire observations detected by MODIS (Moderate Resolution Imaging Spectroradiometer) satellite sensors.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `acq_date`   | String |
+|  `acq_time` | Int |
+| `bright_t31` | Double |
+| `brightness` | Double |
+| `daynight` | String |
+| `frp` | Double |
+| `instrument` | String |
+| `latitude` | Double |
+| `longitude` | Double |
+| `satellite` | String |
+
+- **fires_viirs** - Includes Australian fire observations detected by VIIRS (Visible Infrared Imaging Radiometer Suite) satellite sensors.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `acq_date`   | String |
+|  `acq_time` | Int |
+| `bright_ti4` | Double |
+| `bright_ti5` | Double |
+| `frp` | Double |
+| `instrument` | String |
+| `latitude` | Double |
+| `longitude` | Double |
+| `satellite` | String |
+
+- **historicalFires** - Includes information about past Australian fire seasons.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `Date`   | String |
+|  `Name` | String |
+| `State(s)/territories` | String |
+| `AreaBurned(ha)` | Int |
+| `AreaBurned(acres)` | Int |
+| `Fatalities` | Int |
+| `PropertiesDamaged(HomesDestroyed)` | Int |
+| `Year` | Int |
+
+- **temp_rainfall** - Includes Australian average annual max temperature and rainfall observations from 1956-2019.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `Year`   | Int |
+|  `Avg Annual Temp` | Double|
+| `Avg Annual Rainfall` | Double |
+| `temp_differnce` | Double |
+| `rainfall_difference` | Double |
+
+- **bushfiresbyState** - Includes information about the 2019-2020 Australian bushfire season by state.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `State/Territory`   | String |
+|  `Fatalities` | Int |
+| `Homeslost` | Int |
+| `Areaestimated(ha)` | Int |
+| `Areaestimated(acres)` | Int |
+
+- **aus2019_2020** - Includes additional information about the 2019-2020 bushfire season.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `Fire`   | String |
+|  `Name` | String |
+| `State` | String |
+| `Local Government Area(s)` | String |
+| `AreaImpacted(ha)` | Int |
+
+- **fires_time_series** - Includes the number of fire observations captured by NASA satellites each day
+during the 2019-20 Australia fire season. This collection is used to create the D3 time series chart for this project.
+
+| Field       | Type
+| :------------- | :----------: |
+|  `_id` | ObjectId |
+| `acq_date`   | String |
+|  `number_fires` | Int |
+


### PR DESCRIPTION
This reorganizes the README a bit, moving the data-related content into its own page (since it's so detailed) and adding explicit directions for running the database locally and getting it onto Heroku (the content was there, I just put it into discrete "Steps" and contextualized things a bit). 

Where possible, I also updated links for accessibility (e.g. changing "here" to "our website" to make it better for screenreaders).

I also added a license, to bring us into best practices for having compete a complete README. I chose MIT, but I'm happy to discuss.